### PR TITLE
 pushdown catalyst filters to be able to qualify columns

### DIFF
--- a/src/main/scala/tech/sourced/gitbase/spark/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/DefaultSource.scala
@@ -61,11 +61,11 @@ case class DefaultReader(servers: Seq[GitbaseServer],
                          source: DataSource
                         ) extends DataSourceReader
   with SupportsPushDownRequiredColumns
-  with SupportsPushDownFilters
+  with SupportsPushDownCatalystFilters
   with Logging {
 
   private var requiredSchema = schema
-  private var filters: Array[Filter] = Array()
+  private var filters: Array[Expression] = Array()
 
   override def readSchema(): StructType = requiredSchema
 
@@ -89,13 +89,13 @@ case class DefaultReader(servers: Seq[GitbaseServer],
     this.requiredSchema = requiredSchema
   }
 
-  override def pushFilters(filters: Array[Filter]): Array[Filter] = {
-    val compiled = filters.map(f => (QueryBuilder.compileFilter(f).orNull, f))
+  override def pushCatalystFilters(filters: Array[Expression]): Array[Expression] = {
+    val compiled = filters.map(f => (QueryBuilder.compileExpression(f).orNull, f))
     this.filters = compiled.filter(_._1 != null).map(_._2)
     compiled.filter(_._1 == null).map(_._2)
   }
 
-  override def pushedFilters(): Array[Filter] = filters
+  override def pushedCatalystFilters(): Array[Expression] = filters
 
 }
 

--- a/src/test/scala/tech/sourced/gitbase/spark/QueryBuilderSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/QueryBuilderSpec.scala
@@ -3,12 +3,11 @@ package tech.sourced.gitbase.spark
 import java.sql.{Date, Timestamp}
 
 import org.apache.spark.sql.catalyst.expressions.Literal
-import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{IntegerType, MetadataBuilder, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 import org.scalatest.{FlatSpec, Matchers}
 import QueryBuilder._
-import org.apache.spark.sql.catalyst.expressions
+import org.apache.spark.sql.catalyst.expressions._
 
 class QueryBuilderSpec extends FlatSpec with Matchers {
 
@@ -39,43 +38,16 @@ class QueryBuilderSpec extends FlatSpec with Matchers {
     }
   }
 
-  "QueryBuilder.compileFilter" should "compile the filters to SQL" in {
-    val col = qualify("foo", "bar")
-    val cases = Seq(
-      (EqualTo(col, Literal(1, IntegerType)), s"$col = 1"),
-      (EqualNullSafe(col, Literal(1, IntegerType)),
-        s"(NOT ($col != 1 OR $col IS NULL OR 1 IS NULL) OR ($col IS NULL AND 1 IS NULL))"),
-      (LessThan(col, Literal(1, IntegerType)), s"$col < 1"),
-      (GreaterThan(col, Literal(1, IntegerType)), s"$col > 1"),
-      (LessThanOrEqual(col, Literal(1, IntegerType)), s"$col <= 1"),
-      (GreaterThanOrEqual(col, Literal(1, IntegerType)), s"$col >= 1"),
-      (IsNull(col), s"$col IS NULL"),
-      (IsNotNull(col), s"$col IS NOT NULL"),
-      (In(col, Array()), s"CASE WHEN $col IS NULL THEN NULL ELSE FALSE END"),
-      (In(col, Array(Literal(1, IntegerType), Literal(2, IntegerType))), s"$col IN (1, 2)"),
-      (Not(EqualTo(col, Literal(1, IntegerType))), s"(NOT ($col = 1))"),
-      (Or(EqualTo(col, Literal(1, IntegerType)),
-        EqualTo(col, Literal(2, IntegerType))), s"($col = 1) OR ($col = 2)"),
-      (And(EqualTo(col, Literal(1, IntegerType)),
-        EqualTo(col, Literal(2, IntegerType))), s"($col = 1) AND ($col = 2)")
-    )
-
-    cases.foreach {
-      case (expr, expected) =>
-        compileFilter(expr).get should be(expected)
-    }
-  }
-
   "QueryBuilder.whereClause" should "return SQL for where clause" in {
     QueryBuilder().whereClause should be("")
 
     QueryBuilder(filters = Seq(
-      EqualTo(qualify("foo", "bar"), Literal(1, IntegerType))
+      EqualTo(mkAttr("foo", "bar"), Literal(1, IntegerType))
     )).whereClause should be(s"WHERE ${qualify("foo", "bar")} = 1")
 
     QueryBuilder(filters = Seq(
-      EqualTo(qualify("foo", "bar"), Literal(1, IntegerType)),
-      EqualTo(qualify("foo", "baz"), Literal(2, IntegerType))
+      EqualTo(mkAttr("foo", "bar"), Literal(1, IntegerType)),
+      EqualTo(mkAttr("foo", "bar"), Literal(2, IntegerType))
     )).whereClause should be(s"WHERE ${qualify("foo", "bar")} = 1 AND ${qualify("foo", "baz")} = 2")
   }
 
@@ -87,7 +59,7 @@ class QueryBuilderSpec extends FlatSpec with Matchers {
     QueryBuilder(source = JoinedSource(
       TableSource("foo"),
       TableSource("bar"),
-      Some(expressions.EqualTo(
+      Some(EqualTo(
         mkAttr("foo", "a"),
         mkAttr("bar", "a")
       ))
@@ -97,13 +69,13 @@ class QueryBuilderSpec extends FlatSpec with Matchers {
       JoinedSource(
         TableSource("foo"),
         TableSource("bar"),
-        Some(expressions.EqualTo(
+        Some(EqualTo(
           mkAttr("foo", "a"),
           mkAttr("bar", "a")
         ))
       ),
       TableSource("baz"),
-      Some(expressions.EqualTo(
+      Some(EqualTo(
         mkAttr("foo", "a"),
         mkAttr("baz", "a")
       ))
@@ -112,8 +84,6 @@ class QueryBuilderSpec extends FlatSpec with Matchers {
   }
 
   "QueryBuilder.compileExpression" should "compile the expressions to SQL" in {
-    import org.apache.spark.sql.catalyst.expressions._
-
     val cases = Seq(
       (EqualTo(mkAttr("foo", "a"), Literal(1, IntegerType)),
         "foo.a = 1"),
@@ -166,8 +136,8 @@ class QueryBuilderSpec extends FlatSpec with Matchers {
 }
 
 object QueryBuilderUtil {
-  def mkAttr(table: String, name: String): expressions.Attribute = {
+  def mkAttr(table: String, name: String): Attribute = {
     val metadata = new MetadataBuilder().putString(Sources.SourceKey, table).build()
-    expressions.AttributeReference(name, StringType, nullable = false, metadata)()
+    AttributeReference(name, StringType, nullable = false, metadata)()
   }
 }


### PR DESCRIPTION
Depends on #10 

Fixes #9 

Problem was we were pushing down `Filter`s, not catalyst `Expression`s. The formers don't have the metadata so we don't know how to qualify the column and thus we can't build the query correctly.

As a side effect, we no longer have to maintain both compileFilter and compileExpression, so that's nice.