### PR TITLE
Reduce logs on tests.

### DIFF
--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,10 @@
+# Define the root logger with appender
+log4j.rootCategory=ERROR, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.eclipse.jetty=ERROR
+log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR


### PR DESCRIPTION
Avoid unnecesary long log files on testing to be able to check failed tests easly.

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>