### PR TITLE
Add uast_extract_parse function

### DIFF
--- a/src/main/scala/tech/sourced/gitbase/spark/udf/UastExtract.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/udf/UastExtract.scala
@@ -3,21 +3,26 @@ package tech.sourced.gitbase.spark.udf
 import gopkg.in.bblfsh.sdk.v1.uast.generated.Position
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
+import com.fasterxml.jackson.databind.ObjectMapper
+
+import scala.collection.JavaConverters.asJavaIterableConverter
 
 object UastExtract extends CustomUDF {
+  private val mapper = new ObjectMapper()
+
   /** Name of the function. */
   override def name: String = "uast_extract"
 
   /** Function to execute when this function is called. */
   override def function: UserDefinedFunction = udf(extract _)
 
-  def extract(marshaledNodes: Array[Byte], key: String): Option[Seq[String]] = {
+  def extract(marshaledNodes: Array[Byte], key: String): Option[Array[Byte]] = {
     if (Option(key).getOrElse("") == "" ||
       Option(marshaledNodes).getOrElse(Array.emptyByteArray).length == 0) {
       None
     } else {
       val nodes = BblfshUtils.unmarshalNodes(marshaledNodes).getOrElse(Seq.empty)
-      Some(nodes.flatMap(node => {
+      val stringSeq = nodes.flatMap(node => {
         key match {
           case "@type" => Seq(node.internalType)
           case "@token" => Seq(node.token)
@@ -26,7 +31,9 @@ object UastExtract extends CustomUDF {
           case "@endpos" => Seq(node.startPosition.getOrElse(Position()).toProtoString)
           case _ => Seq.empty
         }
-      }).filter(_.nonEmpty))
+      }).filter(_.nonEmpty)
+
+      Some(mapper.writeValueAsBytes(stringSeq.asJava))
     }
   }
 }

--- a/src/main/scala/tech/sourced/gitbase/spark/udf/UastExtractParse.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/udf/UastExtractParse.scala
@@ -1,0 +1,30 @@
+package tech.sourced.gitbase.spark.udf
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions.udf
+
+import scala.util.control.NonFatal
+
+object UastExtractParse extends CustomUDF with Logging {
+  private val mapper = new ObjectMapper().registerModule(DefaultScalaModule)
+
+  override def name: String = "uast_extract_parse"
+
+  override def function: UserDefinedFunction = udf(extract _)
+
+  def extract(jsonArray: Array[Byte]): Option[Seq[String]] = {
+    jsonArray match {
+      case a if a == null || a.isEmpty => None
+      case a => try {
+        Some(mapper.readValue(a, classOf[Seq[String]]))
+      } catch {
+        case NonFatal(e) =>
+          log.warn("Error trying to parse info from json array", e)
+          None
+      }
+    }
+  }
+}

--- a/src/main/scala/tech/sourced/gitbase/spark/udf/package.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/udf/package.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.SparkSession
 package object udf {
   private[udf] var spark: SparkSession = _
 
-  private val udfs = Seq(
+  private val gitbaseUdfs = Seq(
     Language,
     Uast,
     UastMode,
@@ -15,10 +15,16 @@ package object udf {
     IsBinary
   )
 
-  def isSupported(name: String): Boolean = udfs.exists(f => f.name == name)
+  private val udfs = Seq(
+    UastExtractParse
+  )
+
+
+  def isSupported(name: String): Boolean = gitbaseUdfs.exists(f => f.name == name)
 
   def registerUDFs(ss: SparkSession): Unit = {
     spark = ss
+    gitbaseUdfs.foreach(f => spark.udf.register(f.name, f.function.withName(f.name)))
     udfs.foreach(f => spark.udf.register(f.name, f.function.withName(f.name)))
   }
 }

--- a/src/test/scala/tech/sourced/gitbase/spark/BaseGitbaseSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/BaseGitbaseSpec.scala
@@ -16,7 +16,7 @@ trait BaseGitbaseSpec extends FlatSpec with Matchers with BeforeAndAfterAll with
 
   private val resourcePath = Paths.get(getClass.getResource("/").toString)
 
-  private val gitbaseVersion = "v0.17.0"
+  private val gitbaseVersion = "v0.18.0-beta.3"
   private val gitbaseImage = "srcd/gitbase"
   private val dockerNetwork = "test-gitbase-spark-connector"
 

--- a/src/test/scala/tech/sourced/gitbase/spark/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/DefaultSourceSpec.scala
@@ -181,19 +181,32 @@ class DefaultSourceSpec extends BaseGitbaseSpec {
   }
 
   it should "extract information from uast udfs" in {
-    val df = spark.sql("SELECT file_path," +
-      " uast_extract(uast(blob_content, language(file_path, blob_content), \"//FuncLit\")," +
-      "  \"internalRole\")" +
-      " FROM files" +
-      " WHERE language(file_path, blob_content) = 'Python'" +
-      " LIMIT 100")
+    val df = spark.sql(
+      """
+          SELECT
+            file_path,
+            uast_extract_parse(
+              uast_extract(
+                uast(
+                  blob_content,
+                  language(
+                    file_path,
+                    blob_content
+                  ),
+                  "//FuncLit"
+                ),
+                "internalRole"
+              )
+            )
+       FROM files
+       WHERE language(file_path, blob_content) = 'Python'
+       LIMIT 100""")
     df.count() should be(2)
-    /* There is a bug preventing this from working.
-    See: https://github.com/src-d/gitbase-spark-connector/issues/32
+
     for (row <- df.collect()) {
       row.length should be(2)
     }
-    */
+
   }
 
 }

--- a/src/test/scala/tech/sourced/gitbase/spark/udf/UastExtractParseSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/udf/UastExtractParseSpec.scala
@@ -1,0 +1,60 @@
+package tech.sourced.gitbase.spark.udf
+
+import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.sql.types.{ArrayType, StringType, StructField}
+
+class UastExtractParseSpec extends BaseUdfSpec {
+
+  import spark.implicits._
+
+  behavior of "UastExtractParse"
+
+  it should "work as a registered UDF" in {
+    val rolesDf = spark.sqlContext.sql("SELECT *, " +
+      "uast_extract_parse(uast_extract(uast(blob_content, language(file_path,blob_content), '')," +
+      " '@role')) AS roles FROM " + BaseUdfSpec.filesName)
+
+    rolesDf.schema.fields should contain(StructField("roles", ArrayType(StringType)))
+  }
+
+  it should "work as an UDF in regular code" in {
+    val rolesDf = filesDf.withColumn(
+      "roles",
+      UastExtractParse(
+        UastExtract(
+          UastMode(lit("annotated"), 'blob_content, Language('file_path, 'blob_content)),
+          lit("@role")
+        )))
+
+    rolesDf.schema.fields should contain(StructField("roles", ArrayType(StringType)))
+  }
+
+  it should "extract properties from UAST nodes" in {
+    val keys = Seq(
+      "@role",
+      "@type",
+      "@token",
+      "@startpos",
+      "@endpos",
+      "foo"
+    )
+
+    keys.foreach(key => {
+      val extractDf = filesDf.withColumn(
+        key,
+        UastExtractParse(
+          UastExtract(
+            UastMode(lit("annotated"), 'blob_content, Language('file_path, 'blob_content)),
+            lit(key)
+          )))
+
+      extractDf.select('file_path, col(key)).collect().foreach(row => row.getString(0) match {
+        case "src/foo.py" | "src/bar.java" | "foo" if Seq("@token", "foo").contains(key) =>
+          row.getAs[Seq[String]](1) should be(empty)
+        case "src/foo.py" | "src/bar.java" | "foo" => row.getAs[Seq[String]](1) should not be empty
+        case _ => row.getAs[Seq[String]](1) should be(null)
+      })
+
+    })
+  }
+}


### PR DESCRIPTION
Fix https://github.com/src-d/gitbase-spark-connector/issues/32

Adding special connector UDF to be able to get the JSON array provided by uast_extract UDF and convert it to an Array[String] on Spark side

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>