### PR TITLE
Fix Binding attribute error

### DIFF
--- a/src/main/scala/tech/sourced/gitbase/spark/Query.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/Query.scala
@@ -27,14 +27,14 @@ case class Query(project: Seq[Expression] = Seq(),
   private def removeSources(e: Seq[Expression]): Seq[Expression] =
     e.map(_.transformUp {
       case x: AttributeReference =>
-        AttributeReference(x.name, x.dataType, x.nullable)()
+        AttributeReference(x.name, x.dataType, x.nullable)(x.exprId, x.qualifier)
     })
 
   private def removeSourcesFromSort(e: Seq[SortOrder]): Seq[SortOrder] =
     e.map(s => {
       val child = s.child.transformUp {
         case x: AttributeReference =>
-          AttributeReference(x.name, x.dataType, x.nullable)()
+          AttributeReference(x.name, x.dataType, x.nullable)(x.exprId, x.qualifier)
       }
       SortOrder(child, s.direction)
     })

--- a/src/main/scala/tech/sourced/gitbase/spark/rule/PushdownAggregations.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/rule/PushdownAggregations.scala
@@ -50,9 +50,9 @@ object PushdownAggregations extends Rule[LogicalPlan] {
         // FIXME: hack to make it work with gitbase. Gitbase emits counts as INTEGER
         // but spark wants longs.
         case e@Alias(Count(_), _) =>
-          AttributeReference(e.name, IntegerType, e.nullable, e.metadata)()
+          AttributeReference(e.name, IntegerType, e.nullable, e.metadata)(e.exprId, e.qualifier)
         case e =>
-          AttributeReference(e.name, e.dataType, e.nullable, e.metadata)()
+          AttributeReference(e.name, e.dataType, e.nullable, e.metadata)(e.exprId, e.qualifier)
       }
 
       val newAggregate = aggregate.map(e => e.transformUp {

--- a/src/main/scala/tech/sourced/gitbase/spark/rule/PushdownTree.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/rule/PushdownTree.scala
@@ -36,7 +36,7 @@ object PushdownTree extends Rule[LogicalPlan] {
           supportedProject.map(e => StructField(e.name, e.dataType, e.nullable, e.metadata))
         )
         val newOutput = supportedProject.map(e =>
-          AttributeReference(e.name, e.dataType, e.nullable, e.metadata)()
+          AttributeReference(e.name, e.dataType, e.nullable, e.metadata)(e.exprId, e.qualifier)
         )
 
         logical.Project(unsupportedProject,
@@ -153,7 +153,9 @@ object PushdownTree extends Rule[LogicalPlan] {
                   namedExpression.name,
                   namedExpression.dataType,
                   namedExpression.nullable,
-                  namedExpression.metadata)()
+                  namedExpression.metadata)
+                (namedExpression.exprId,
+                  namedExpression.qualifier)
               )
             }.unzip
 
@@ -167,7 +169,8 @@ object PushdownTree extends Rule[LogicalPlan] {
           supported = Seq(namedExp)
           unsupported = Some(
             AttributeReference(
-              namedExp.name, namedExp.dataType, namedExp.nullable, namedExp.metadata)())
+              namedExp.name, namedExp.dataType, namedExp.nullable, namedExp.metadata)
+            (namedExp.exprId, namedExp.qualifier))
         case _ =>
       }
 

--- a/src/test/scala/tech/sourced/gitbase/spark/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/DefaultSourceSpec.scala
@@ -227,4 +227,26 @@ class DefaultSourceSpec extends BaseGitbaseSpec {
     ))
   }
 
+  it should "show 20 results without errors" in {
+    val df = spark.sql(
+      """
+        |SELECT
+        |  *
+        |FROM (
+        |  SELECT
+        |    COUNT(c.commit_hash) as num, c.commit_hash
+        |  FROM
+        |    ref_commits r
+        |  INNER JOIN
+        |    commits c
+        |  ON
+        |    r.repository_id = c.repository_id AND r.commit_hash = c.commit_hash
+        |  GROUP BY
+        |    c.commit_hash
+        |) t
+        |WHERE
+        |  num > 1
+      """.stripMargin)
+    df.show(20, false)
+  }
 }


### PR DESCRIPTION
Fix https://github.com/src-d/gitbase-spark-connector/issues/38

- In some places, we were creating new Attribute references without passing the expression id on the constructor, creating more and more expressions instead of reference one from the other. Modified the code to send the expression id from the original expression when possible.

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>
