### PR TITLE
 add reference queries after some fixes

### DIFF
--- a/src/test/scala/tech/sourced/gitbase/spark/rule/BaseRuleSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/rule/BaseRuleSpec.scala
@@ -1,9 +1,9 @@
 package tech.sourced.gitbase.spark.rule
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, ExprId, Expression, NamedExpression}
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.expressions.{
+  AttributeReference, ExprId, Expression, NamedExpression
+}
 import org.apache.spark.sql.types.{DataType, MetadataBuilder, StructType}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers, Suite}
 import tech.sourced.gitbase.spark.{DefaultReader, Node, Sources}


### PR DESCRIPTION
Depends on #70

Added them here as well since most of the time is easier to test here than in gitbase-spark-connector-enterprise, which requires having a release to test stuff.

#61 fixed some issues, but uncovered new ones reported as #62, #63, #64 and #65 (which was already known but not reported)