### PR TITLE
Fix/correctly project after join squash

### DIFF
--- a/src/main/scala/tech/sourced/gitbase/spark/rule/PushdownTree.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/rule/PushdownTree.scala
@@ -163,7 +163,7 @@ object PushdownTree extends Rule[LogicalPlan] {
 
           supported = supportedExp
           unsupported = Some(unsupportedNamedExp)
-        // this expression can be handled and it have no children
+        // this expression can be handled and it has no children
         case e if canBeHandled(e :: Nil) && unsupported.isEmpty =>
           val namedExp = toNamedExpression(e)
           supported = Seq(namedExp)

--- a/src/main/scala/tech/sourced/gitbase/spark/rule/PushdownTree.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/rule/PushdownTree.scala
@@ -13,7 +13,7 @@ import tech.sourced.gitbase.spark._
 
 object PushdownTree extends Rule[LogicalPlan] {
 
-  /** @inheritdoc*/
+  /** @inheritdoc */
   def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
     case logical.Project(exp1, logical.Project(exp2, child))
       if containsDuplicates(exp1 ++ exp2) =>
@@ -113,7 +113,7 @@ object PushdownTree extends Rule[LogicalPlan] {
   private def toNamedExpression(expression: Expression): NamedExpression = {
     expression match {
       case e: NamedExpression => e
-      case e => Alias(e, e.toString())()
+      case e => Alias(e, e.sql)()
     }
   }
 

--- a/src/test/scala/tech/sourced/gitbase/spark/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/DefaultSourceSpec.scala
@@ -210,11 +210,11 @@ class DefaultSourceSpec extends BaseGitbaseSpec {
   }
 
   it should "get commit parents using parse_commit_parents" in {
-    val result = spark.sql("SELECT repository_id, parse_commit_parents(commit_parents) parents" +
+    val result = spark.sql("SELECT repository_id, parse_commit_parents(commit_parents)" +
       " FROM ref_commits" +
       " NATURAL JOIN commits" +
       " WHERE ref_name LIKE 'refs/heads/HEAD/%' AND history_index = 0" +
-      " ORDER BY repository_id, parents")
+      " ORDER BY repository_id, 2")
       .collect()
       .map(row => (row(0), row(1).asInstanceOf[Seq[String]]))
 

--- a/src/test/scala/tech/sourced/gitbase/spark/rule/PushdownTreeSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/rule/PushdownTreeSpec.scala
@@ -1,7 +1,9 @@
 package tech.sourced.gitbase.spark.rule
 
 import org.apache.spark.sql.catalyst.expressions.{
-  Alias, Ascending, Attribute, CaseKeyWhen, Descending, EqualTo, Literal, SortOrder}
+  Alias, Ascending, Attribute, CaseKeyWhen,
+  Descending, EqualTo, Literal, SortOrder
+}
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
@@ -192,4 +194,5 @@ class PushdownTreeSpec extends BaseRuleSpec {
 
     PushdownTree(node).isInstanceOf[logical.GlobalLimit] should be(true)
   }
+
 }


### PR DESCRIPTION
Closes #62 
Depends on #61 

Turns out it was not what I think it was. It's not related to the split of unsupported functions, but a more complicated thing: columns were not being correctly picked for pushed down joins, which lead to some columns not being present.