### PR TITLE
Stream results from JDBC connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Finally you can try it out from your code. Add the gitbase `DataSource` and conf
 ```scala
 import tech.sourced.gitbase.spark.GitbaseSessionBuilder
 
+// Add these lines if your are using spark-shell
+
+// import org.apache.spark.sql.SparkSession
+// SparkSession.setActiveSession(null)
+// SparkSession.setDefaultSession(null)
+
 val spark = SparkSession.builder().appName("test")
     .master("local[*]")
     .config("spark.driver.host", "localhost")

--- a/src/main/scala/tech/sourced/gitbase/spark/Gitbase.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/Gitbase.scala
@@ -32,6 +32,7 @@ case class GitbaseDialect(protocol: String = "jdbc:mariadb") extends JdbcDialect
   * This contains utility methods to perform operations on a Gitbase server.
   */
 object Gitbase {
+  private val RowsPerBatch = 100
 
   private val dialect = GitbaseDialect()
 
@@ -92,14 +93,12 @@ object Gitbase {
     )
 
     val stmt: PreparedStatement = connection.prepareStatement(query)
-    try {
-      val rs = stmt.executeQuery
+    stmt.setFetchSize(RowsPerBatch)
 
-      val schema = JdbcUtils.getSchema(rs, dialect, alwaysNullable = true)
-      (JdbcUtils.resultSetToRows(rs, schema), connection.close)
-    } finally {
-      stmt.close()
-    }
+    val rs = stmt.executeQuery
+
+    val schema = JdbcUtils.getSchema(rs, dialect, alwaysNullable = true)
+    (JdbcUtils.resultSetToRows(rs, schema), connection.close)
   }
 
 }


### PR DESCRIPTION
By default, JDBC mariaDB implementation is fetching all the rows on memory while obtaining a query ResultSet.

Adding a specific fetch size of 100 on the prepared statement we can stream large amounts of data directly from gitbase to a parquet file without memory problems.

Also found a problem related with rule registration on SparkSession using the spark shell. Adding the workaround on the readme example to avoid problems with people trying GSC on the shell directly.

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>