### PR TITLE
Cancel statement on close.

### DIFF
--- a/src/main/scala/tech/sourced/gitbase/spark/Gitbase.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/Gitbase.scala
@@ -98,7 +98,10 @@ object Gitbase {
     val rs = stmt.executeQuery
 
     val schema = JdbcUtils.getSchema(rs, dialect, alwaysNullable = true)
-    (JdbcUtils.resultSetToRows(rs, schema), connection.close)
+    (JdbcUtils.resultSetToRows(rs, schema), () => {
+      stmt.cancel()
+      connection.close()
+    })
   }
 
 }


### PR DESCRIPTION
If the user cancels the job, connection.close() will wait until all the result set is fetched. To avoid that, we cancel the statement too.

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>