### PR TITLE
Remove uast features from spark side

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
   lazy val sparkSql = "org.apache.spark" % "spark-sql_2.11" % "2.3.1"
   lazy val mariaDB = "org.mariadb.jdbc" % "mariadb-java-client" % "2.3.0"
-  lazy val enry = "tech.sourced" % "enry-java" % "1.6.3"
-  lazy val bblfsh = "org.bblfsh" % "bblfsh-client" % "1.10.1"
+  lazy val enry = "tech.sourced" % "enry-java" % "1.7.1"
+  lazy val bblfsh = "org.bblfsh" % "bblfsh-client" % "1.11.0"
   lazy val dockerJava = "com.github.docker-java" % "docker-java" % "3.0.14"
 }

--- a/src/main/scala/tech/sourced/gitbase/spark/udf/Uast.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/udf/Uast.scala
@@ -16,7 +16,10 @@ object Uast extends CustomUDF with Logging {
 
   def get(content: Array[Byte],
           lang: String = "",
-          query: String = ""): Option[Array[Byte]] =
+          query: String = ""): Option[Array[Byte]] = {
+    // TODO remove when bblfsh updates scala client to latest version
+    throwUnsupportedException(name)
+
     try {
       if (content == null || content.isEmpty) {
         return None
@@ -47,4 +50,5 @@ object Uast extends CustomUDF with Logging {
         log.error(s"couldn't get UAST: $e")
         None
     }
+  }
 }

--- a/src/main/scala/tech/sourced/gitbase/spark/udf/UastChildren.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/udf/UastChildren.scala
@@ -11,6 +11,9 @@ object UastChildren extends CustomUDF {
   override def function: UserDefinedFunction = udf(get _)
 
   def get(marshaledNodes: Array[Byte]): Option[Array[Byte]] = {
+    // TODO remove when bblfsh updates scala client to latest version
+    throwUnsupportedException(name)
+
     val nodes = BblfshUtils.unmarshalNodes(marshaledNodes).getOrElse(Seq.empty)
     val children = nodes.flatMap(_.children)
     BblfshUtils.marshalNodes(children)

--- a/src/main/scala/tech/sourced/gitbase/spark/udf/UastExtract.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/udf/UastExtract.scala
@@ -1,9 +1,9 @@
 package tech.sourced.gitbase.spark.udf
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import gopkg.in.bblfsh.sdk.v1.uast.generated.Position
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
-import com.fasterxml.jackson.databind.ObjectMapper
 
 import scala.collection.JavaConverters.asJavaIterableConverter
 
@@ -17,6 +17,9 @@ object UastExtract extends CustomUDF {
   override def function: UserDefinedFunction = udf(extract _)
 
   def extract(marshaledNodes: Array[Byte], key: String): Option[Array[Byte]] = {
+    // TODO remove when bblfsh updates scala client to latest version
+    throwUnsupportedException(name)
+
     if (Option(key).getOrElse("") == "" ||
       Option(marshaledNodes).getOrElse(Array.emptyByteArray).length == 0) {
       None

--- a/src/main/scala/tech/sourced/gitbase/spark/udf/UastMode.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/udf/UastMode.scala
@@ -16,6 +16,8 @@ object UastMode extends CustomUDF with Logging {
   def get(mode: String = "annotated",
           content: Array[Byte],
           lang: String = ""): Option[Array[Byte]] = {
+    // TODO remove when bblfsh updates scala client to latest version
+    throwUnsupportedException(name)
 
     if (content == null || content.isEmpty) {
       None

--- a/src/main/scala/tech/sourced/gitbase/spark/udf/UastXPath.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/udf/UastXPath.scala
@@ -1,8 +1,8 @@
 package tech.sourced.gitbase.spark.udf
 
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.bblfsh.client.BblfshClient
 import org.apache.spark.sql.functions.udf
+import org.bblfsh.client.BblfshClient
 
 object UastXPath extends CustomUDF {
   /** Name of the function. */
@@ -12,6 +12,9 @@ object UastXPath extends CustomUDF {
   override def function: UserDefinedFunction = udf(get _)
 
   def get(marshaledNodes: Array[Byte], query: String): Option[Array[Byte]] = {
+    // TODO remove when bblfsh updates scala client to latest version
+    throwUnsupportedException(name)
+
     val nodes = BblfshUtils.unmarshalNodes(marshaledNodes).getOrElse(Seq())
     val filtered = nodes.flatMap(BblfshClient.filter(_, query))
     BblfshUtils.marshalNodes(filtered)

--- a/src/main/scala/tech/sourced/gitbase/spark/udf/package.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/udf/package.scala
@@ -2,6 +2,7 @@ package tech.sourced.gitbase.spark
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 
@@ -25,6 +26,10 @@ package object udf {
     ParseCommitParents
   )
 
+
+  private[udf] def throwUnsupportedException(name:String) =
+    throw new SparkException(s"Function with name $name is not supported on Spark side. " +
+    s"Please change your query to make it being executed on gitbase.")
 
   def isSupported(name: String): Boolean = gitbaseUdfs.exists(f => f.name == name)
 

--- a/src/test/scala/tech/sourced/gitbase/spark/udf/UastChildrenSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/udf/UastChildrenSpec.scala
@@ -4,6 +4,7 @@ import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.types.{BinaryType, StructField}
 
 class UastChildrenSpec extends BaseUdfSpec {
+
   import spark.implicits._
 
   behavior of "UastChildren"
@@ -28,7 +29,8 @@ class UastChildrenSpec extends BaseUdfSpec {
     childrenDf.schema.fields should contain(StructField("children", BinaryType))
   }
 
-  it should "return the children of the given nodes" in {
+  // TODO add test again when bblfsh updates scala client to latest version
+  it should "return the children of the given nodes" ignore {
     val childrenDf = filesDf.withColumn(
       "children",
       UastChildren(UastMode(
@@ -39,7 +41,7 @@ class UastChildrenSpec extends BaseUdfSpec {
 
     childrenDf.select('file_path, 'children).collect().foreach(row => row.getString(0) match {
       case ("src/foo.py" | "src/bar.java" | "foo") => row.getAs[Array[Byte]](1) should not be empty
-      case _ => row.getAs[Array[Byte]](1) should be (null)
+      case _ => row.getAs[Array[Byte]](1) should be(null)
     })
   }
 }

--- a/src/test/scala/tech/sourced/gitbase/spark/udf/UastExtractParseSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/udf/UastExtractParseSpec.scala
@@ -29,7 +29,8 @@ class UastExtractParseSpec extends BaseUdfSpec {
     rolesDf.schema.fields should contain(StructField("roles", ArrayType(StringType)))
   }
 
-  it should "extract properties from UAST nodes" in {
+  // TODO add test again when bblfsh updates scala client to latest version
+  it should "extract properties from UAST nodes" ignore {
     val keys = Seq(
       "@role",
       "@type",

--- a/src/test/scala/tech/sourced/gitbase/spark/udf/UastExtractSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/udf/UastExtractSpec.scala
@@ -28,7 +28,8 @@ class UastExtractSpec extends BaseUdfSpec {
     rolesDf.schema.fields should contain(StructField("roles", BinaryType))
   }
 
-  it should "extract properties from UAST nodes" in {
+  // TODO add test again when bblfsh updates scala client to latest version
+  it should "extract properties from UAST nodes" ignore {
     val keys = Seq(
       "@role",
       "@type",

--- a/src/test/scala/tech/sourced/gitbase/spark/udf/UastModeSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/udf/UastModeSpec.scala
@@ -25,7 +25,8 @@ class UastModeSpec extends BaseUdfSpec {
     uastModeDf.schema.fields should contain(StructField("uast", BinaryType))
   }
 
-  it should "retrieve UASTs with specific mode" in {
+  // TODO add test again when bblfsh updates scala client to latest version
+  it should "retrieve UASTs with specific mode" ignore {
     info("Note that the uast_mode udf checks that the given mode is " +
       "one of (annotated, semantic, native).\nEven though, it will always" +
       " return an annotated uast since org.bblfsh.client.BblfshClient " +

--- a/src/test/scala/tech/sourced/gitbase/spark/udf/UastSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/udf/UastSpec.scala
@@ -27,7 +27,8 @@ class UastSpec extends BaseUdfSpec {
     uastDf.schema.fields should contain(StructField("uast", BinaryType))
   }
 
-  it should "retrieve UASTs" in {
+  // TODO add test again when bblfsh updates scala client to latest version
+  it should "retrieve UASTs" ignore {
     val xpath = ""
     val uastDf = filesDf.withColumn(
       "uast",
@@ -47,7 +48,8 @@ class UastSpec extends BaseUdfSpec {
     })
   }
 
-  it should "ignore unsupported languages" in {
+  // TODO add test again when bblfsh updates scala client to latest version
+  it should "ignore unsupported languages" ignore {
     val uastDf = filesDf.withColumn(
       "uast",
       Uast('blob_content, lit("text"), lit(""))

--- a/src/test/scala/tech/sourced/gitbase/spark/udf/UastXPathSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/udf/UastXPathSpec.scala
@@ -4,6 +4,7 @@ import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.types.{BinaryType, StructField}
 
 class UastXPathSpec extends BaseUdfSpec {
+
   import spark.implicits._
 
   behavior of "UastXPath"
@@ -29,7 +30,8 @@ class UastXPathSpec extends BaseUdfSpec {
     filteredDf.schema.fields should contain(StructField("filtered", BinaryType))
   }
 
-  it should "filter UASTs with the given XPath query" in {
+  // TODO add test again when bblfsh updates scala client to latest version
+  it should "filter UASTs with the given XPath query" ignore {
     val xpath = "//*[@roleFunction]"
     val filteredDf = filesDf.withColumn(
       "filtered",
@@ -41,7 +43,7 @@ class UastXPathSpec extends BaseUdfSpec {
 
     filteredDf.select('file_path, 'filtered).collect().foreach(row => row.getString(0) match {
       case "src/foo.py" => row.getAs[Array[Byte]](1) should not be empty
-      case _ => row.getAs[Array[Byte]](1) should be (null)
+      case _ => row.getAs[Array[Byte]](1) should be(null)
     })
   }
 }


### PR DESCRIPTION
If some uast udf is being used on spark side, it will throw an error now until we update scala client to avoid different results from gitbase and spark.

Update enry and bblfsh to latest versions.

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>