### PR TITLE
add uast and uast_mode expressions with optional parameters

### DIFF
--- a/src/main/scala/tech/sourced/gitbase/spark/QueryBuilder.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/QueryBuilder.scala
@@ -5,6 +5,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference,
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.types._
+import tech.sourced.gitbase.spark.udf.{Uast, UastMode}
 
 object QueryBuilder {
 
@@ -168,6 +169,22 @@ object QueryBuilder {
       // distinct in aggregations yet.
       case AggregateExpression(fn, _, false, _) =>
         compileExpression(fn)
+
+      case Uast(children) =>
+        val args = children.map(compileExpression)
+        if (args.forall(_.isDefined)) {
+          Some(s"`uast`(${args.map(_.get).mkString(", ")})")
+        } else {
+          None
+        }
+
+      case UastMode(children) =>
+        val args = children.map(compileExpression)
+        if (args.forall(_.isDefined)) {
+          Some(s"`uast_mode`(${args.map(_.get).mkString(", ")})")
+        } else {
+          None
+        }
 
       case _ => None
     }

--- a/src/main/scala/tech/sourced/gitbase/spark/udf/CustomUDF.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/udf/CustomUDF.scala
@@ -1,6 +1,9 @@
 package tech.sourced.gitbase.spark.udf
 
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.expressions.UserDefinedFunction
 
 /**
@@ -14,4 +17,16 @@ abstract class CustomUDF {
   def function: UserDefinedFunction
 
   def apply(exprs: Column*): Column = function.withName(name)(exprs: _*)
+}
+
+/**
+  * Custom named user defined expression.
+  */
+abstract class CustomExprFunction {
+  /** Name of the expression. */
+  def name: String
+
+  /** Function of the expression. */
+  def function: FunctionBuilder
+
 }

--- a/src/main/scala/tech/sourced/gitbase/spark/udf/Uast.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/udf/Uast.scala
@@ -1,18 +1,68 @@
 package tech.sourced.gitbase.spark.udf
 
 import gopkg.in.bblfsh.sdk.v1.protocol.generated.Status
+import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types.{BinaryType, DataType}
 import org.bblfsh.client.BblfshClient
+import tech.sourced.enry.Enry
 
+case class Uast(exprs: Seq[Expression]) extends Expression with CodegenFallback {
 
-object Uast extends CustomUDF with Logging {
-  /** Name of the function. */
-  override val name: String = "uast"
+  override def nullable: Boolean = true
 
-  /** Function to execute when this function is called. */
-  override def function: UserDefinedFunction = udf(get _)
+  override def toString: String = s"uast(${exprs.mkString(", ")})"
+
+  override def children: Seq[Expression] = exprs
+
+  override def eval(inputRow: InternalRow): Any = {
+    val args = exprs.map(_.eval(inputRow))
+    var query = ""
+    var content: Array[Byte] = null
+    var lang = ""
+
+    args.length match {
+      case 1 =>
+        content = args.head.asInstanceOf[Array[Byte]]
+      case 2 =>
+        content = args.head.asInstanceOf[Array[Byte]]
+        lang = Option(args(1)).map(_.toString).orNull
+      case 3 =>
+        content = args.head.asInstanceOf[Array[Byte]]
+        lang = Option(args(1)).map(_.toString).orNull
+        query = Option(args(2)).map(_.toString).orNull
+      case ln =>
+        throw new SparkException(
+          s"invalid arguments provided to uast, expecting 1, 2 or 3, got $ln"
+        )
+    }
+
+    if (lang == null || content == null || query == null) {
+      return null
+    }
+
+    if (lang == "") {
+      lang = Enry.getLanguage("file", content)
+    }
+
+    Uast.get(content, lang, query).orNull
+  }
+
+  override def dataType: DataType = BinaryType
+
+}
+
+object Uast extends CustomExprFunction with Logging {
+
+  override def name: String = "uast"
+  override def function: FunctionBuilder = exprs => Uast(exprs)
+
+  def apply(cols: Column*): Column = new Column(Uast(cols.map(_.expr)))
 
   def get(content: Array[Byte],
           lang: String = "",
@@ -36,9 +86,7 @@ object Uast extends CustomUDF with Logging {
 
       val nodes = query match {
         case "" => Seq(res.uast.get)
-        case q: String => {
-          BblfshClient.filter(res.uast.get, q)
-        }
+        case q: String => BblfshClient.filter(res.uast.get, q)
       }
 
       BblfshUtils.marshalNodes(nodes)

--- a/src/main/scala/tech/sourced/gitbase/spark/udf/UastMode.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/udf/UastMode.scala
@@ -1,31 +1,71 @@
 package tech.sourced.gitbase.spark.udf
 
+import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types.{BinaryType, DataType}
+import tech.sourced.enry.Enry
 
-object UastMode extends CustomUDF with Logging {
-  /** Name of the function. */
-  override def name: String = "uast_mode"
+case class UastMode(exprs: Seq[Expression]) extends Expression with CodegenFallback with Logging {
 
-  /** Function to execute when this function is called. */
-  override def function: UserDefinedFunction = udf(get _)
+  override def nullable: Boolean = true
+
+  override def toString: String = s"uast_mode(${exprs.mkString(", ")})"
+
+  override def children: Seq[Expression] = exprs
 
   private val modes = Seq("annotated", "semantic", "native")
 
-  def get(mode: String = "annotated",
-          content: Array[Byte],
-          lang: String = ""): Option[Array[Byte]] = {
+  override def eval(inputRow: InternalRow): Any = {
+    val args = exprs.map(_.eval(inputRow))
+    var mode = "annotated"
+    var content: Array[Byte] = null
+    var lang = ""
 
-    if (content == null || content.isEmpty) {
-      None
+    args.length match {
+      case 2 =>
+        mode = Option(args.head).map(_.toString).orNull
+        content = args(1).asInstanceOf[Array[Byte]]
+      case 3 =>
+        mode = Option(args.head).map(_.toString).orNull
+        content = args(1).asInstanceOf[Array[Byte]]
+        lang = Option(args(2)).map(_.toString).orNull
+      case ln =>
+        throw new SparkException(
+          s"invalid arguments provided to uast_mode, expecting 2 or 3, got $ln"
+        )
+    }
+
+    if (lang == null || content == null || mode == null) {
+      return null
+    }
+
+    if (lang == "") {
+      lang = Enry.getLanguage("file", content)
+    }
+
+    if (!modes.contains(mode)) {
+      log.error(s"wrong mode $mode found in call to udf uast_mode")
+      null
     } else {
-      if (modes.contains(mode)) {
-        Uast.get(content, Option(lang).getOrElse(""))
-      } else {
-        log.error(s"wrong mode type ${mode} found in call to udf ${name}")
-        None
-      }
+      // TODO: mode is not yet supported in the scala client version used.
+      val result = Uast.get(content, lang).orNull
+      result
     }
   }
+
+  override def dataType: DataType = BinaryType
+
+}
+
+object UastMode extends CustomExprFunction {
+  override def name: String = "uast_mode"
+
+  override def function: FunctionBuilder = exprs => UastMode(exprs)
+
+  def apply(cols: Column*): Column = new Column(UastMode(cols.map(_.expr)))
 }

--- a/src/test/scala/tech/sourced/gitbase/spark/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/DefaultSourceSpec.scala
@@ -219,11 +219,14 @@ class DefaultSourceSpec extends BaseGitbaseSpec {
       .map(row => (row(0), row(1).asInstanceOf[Seq[String]]))
 
     result should equal(Array(
-      ("05893125684f2d3943cd84a7ab2b75e53668fba1.siva", Seq("05e39f6b6f89eb7f9e53e42bffae844b5d869b90")),
+      ("05893125684f2d3943cd84a7ab2b75e53668fba1.siva",
+        Seq("05e39f6b6f89eb7f9e53e42bffae844b5d869b90")),
       ("fff7062de8474d10a67d417ccea87ba6f58ca81d.siva", Seq()),
       ("fff7062de8474d10a67d417ccea87ba6f58ca81d.siva", Seq()),
-      ("fff840f8784ef162dc83a1465fc5763d890b68ba.siva", Seq("9956dc89b79e37e99ec09a7c3dc18291622cfc26")),
-      ("fff840f8784ef162dc83a1465fc5763d890b68ba.siva", Seq("e9276d0ef0c802bc268eea56d05c0abca4d37ee0"))
+      ("fff840f8784ef162dc83a1465fc5763d890b68ba.siva",
+        Seq("9956dc89b79e37e99ec09a7c3dc18291622cfc26")),
+      ("fff840f8784ef162dc83a1465fc5763d890b68ba.siva",
+        Seq("e9276d0ef0c802bc268eea56d05c0abca4d37ee0"))
     ))
   }
 

--- a/src/test/scala/tech/sourced/gitbase/spark/QueryBuilderSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/QueryBuilderSpec.scala
@@ -162,7 +162,7 @@ class QueryBuilderSpec extends FlatSpec with Matchers {
   "QueryBuilder.limitClause" should "return the limit clause" in {
     val qb = QueryBuilder()
     qb.limitClause() should be("")
-    qb.limitClause(Query(limit=Some(5L))) should be(" LIMIT 5")
+    qb.limitClause(Query(limit = Some(5L))) should be(" LIMIT 5")
   }
 
   "QueryBuilder.compileExpression" should "compile the expressions to SQL" in {
@@ -331,7 +331,11 @@ class QueryBuilderSpec extends FlatSpec with Matchers {
       (Language(mkCol("foo", "a"), mkCol("foo", "b")),
         "`language`(foo.`a`, foo.`b`)"),
 
-      (Uast(mkCol("foo", "a"), mkCol("foo", "b"), mkCol("foo", "c")),
+      (new Column(Uast(Seq(
+        mkCol("foo", "a").expr,
+        mkCol("foo", "b").expr,
+        mkCol("foo", "c").expr
+      ))),
         "`uast`(foo.`a`, foo.`b`, foo.`c`)"),
 
       (UastChildren(mkCol("foo", "a")),
@@ -340,7 +344,11 @@ class QueryBuilderSpec extends FlatSpec with Matchers {
       (UastExtract(mkCol("foo", "a"), mkCol("foo", "b")),
         "`uast_extract`(foo.`a`, foo.`b`)"),
 
-      (UastMode(mkCol("foo", "a"), mkCol("foo", "b"), mkCol("foo", "c")),
+      (new Column(UastMode(Seq(
+        mkCol("foo", "a").expr,
+        mkCol("foo", "b").expr,
+        mkCol("foo", "c").expr
+      ))),
         "`uast_mode`(foo.`a`, foo.`b`, foo.`c`)"),
 
       (UastXPath(mkCol("foo", "a"), mkCol("foo", "b")),

--- a/src/test/scala/tech/sourced/gitbase/spark/udf/BaseUdfSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/udf/BaseUdfSpec.scala
@@ -31,7 +31,7 @@ private object BaseUdfSpec {
   val filesRows = Seq(
     ("repo", "path", "bhash", "thash", "entry", null, 0),
     ("repo-1", "src/foo.py", "hash1", "", "",
-      "with open('somefile.txt') as f: contents=f.read()".getBytes, 0),
+      "#!/usr/bin/env python\n\nwith open('somefile.txt') as f: contents=f.read()".getBytes, 0),
     ("repo-1", "src/bar.java", "hash2", "", "",
       "public class Hello extends GenericServlet { }".getBytes, 0),
     ("repo-1", "src/baz.go", "hash3", "", "", null.asInstanceOf[Array[Byte]], 0),

--- a/src/test/scala/tech/sourced/gitbase/spark/udf/UastChildrenSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/udf/UastChildrenSpec.scala
@@ -4,6 +4,7 @@ import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.types.{BinaryType, StructField}
 
 class UastChildrenSpec extends BaseUdfSpec {
+
   import spark.implicits._
 
   behavior of "UastChildren"
@@ -38,8 +39,8 @@ class UastChildrenSpec extends BaseUdfSpec {
     )
 
     childrenDf.select('file_path, 'children).collect().foreach(row => row.getString(0) match {
-      case ("src/foo.py" | "src/bar.java" | "foo") => row.getAs[Array[Byte]](1) should not be empty
-      case _ => row.getAs[Array[Byte]](1) should be (null)
+      case "src/foo.py" | "src/bar.java" | "foo" => row.getAs[Array[Byte]](1) should not be empty
+      case _ => row.getAs[Array[Byte]](1) should be(null)
     })
   }
 }

--- a/src/test/scala/tech/sourced/gitbase/spark/udf/UastModeSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/udf/UastModeSpec.scala
@@ -4,13 +4,14 @@ import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.types.{BinaryType, StructField}
 
 class UastModeSpec extends BaseUdfSpec {
+
   import spark.implicits._
 
   behavior of "UastMode"
 
   it should "work as a registered UDF" in {
     val uastModeDf = spark.sqlContext.sql("SELECT *,"
-      + UastMode.name +"('foo',blob_content,language(file_path,blob_content)) AS uast FROM " +
+      + "uast_mode('foo',blob_content,language(file_path,blob_content)) AS uast FROM " +
       BaseUdfSpec.filesName)
 
     uastModeDf.schema.fields should contain(StructField("uast", BinaryType))
@@ -37,15 +38,14 @@ class UastModeSpec extends BaseUdfSpec {
     )
 
     annotatedDf.select('file_path, 'uast).collect().foreach(row => row.getString(0) match {
-      case ("src/foo.py" | "src/bar.java" | "foo") => {
+      case "src/foo.py" | "src/bar.java" | "foo" =>
         val marshaledNodes = row.getAs[Array[Byte]](1)
         marshaledNodes should not be empty
 
         val nodes = BblfshUtils.unmarshalNodes(marshaledNodes).getOrElse(Seq.empty)
         nodes should not be empty
         nodes should have length 1
-      }
-      case _ => row.getAs[Array[Byte]](1) should be (null)
+      case _ => row.getAs[Array[Byte]](1) should be(null)
     })
 
     val fooDf = filesDf.withColumn(
@@ -56,6 +56,38 @@ class UastModeSpec extends BaseUdfSpec {
     fooDf
       .select('uast)
       .collect()
-      .foreach(row => row.getAs[Array[Byte]](0) should be (null))
+      .foreach(row => row.getAs[Array[Byte]](0) should be(null))
+  }
+
+  it should "work without language" in {
+    val annotatedDf = filesDf.withColumn(
+      "uast",
+      UastMode(lit("annotated"), 'blob_content)
+    )
+
+    annotatedDf.select('file_path, 'uast).collect().foreach(row => row.getString(0) match {
+      case "src/foo.py" | "foo" =>
+        val marshaledNodes = row.getAs[Array[Byte]](1)
+        marshaledNodes should not be empty
+
+        val nodes = BblfshUtils.unmarshalNodes(marshaledNodes).getOrElse(Seq.empty)
+        nodes should not be empty
+        nodes should have length 1
+      case _ => row.getAs[Array[Byte]](1) should be(null)
+    })
+
+    val fooDf = filesDf.withColumn(
+      "uast",
+      UastMode(
+        lit("foo"),
+        'blob_content,
+        Language('file_path, 'blob_content)
+      )
+    )
+
+    fooDf
+      .select('uast)
+      .collect()
+      .foreach(row => row.getAs[Array[Byte]](0) should be(null))
   }
 }


### PR DESCRIPTION
Fixes #83 

After some digging (because apparently there is nothing written on the internet about it) found a way to register expressions and implement custom ones.

It's rather low level, but since we won't do this for more than a couple functions I guess it's fine.