### PR TITLE
fix quoting of identifiers in gitbase dialect for JDBC

### DIFF
--- a/src/main/scala/tech/sourced/gitbase/spark/Gitbase.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/Gitbase.scala
@@ -26,6 +26,10 @@ case class GitbaseDialect(protocol: String = "jdbc:mariadb") extends JdbcDialect
     case _ => super.compileValue(value)
   }
 
+  override def quoteIdentifier(ident: String): String = {
+    s"`$ident`"
+  }
+
 }
 
 /**

--- a/src/main/scala/tech/sourced/gitbase/spark/package.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/package.scala
@@ -4,6 +4,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.jdbc.JdbcDialects
 import tech.sourced.gitbase.spark.udf.BblfshUtils
 
 package object spark {
@@ -29,6 +30,7 @@ package object spark {
       val ss = builder.getOrCreate()
       udf.registerUDFs(ss)
       createTempViews(ss)
+      JdbcDialects.registerDialect(GitbaseDialect())
 
       builder
     }

--- a/src/test/scala/tech/sourced/gitbase/spark/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/gitbase/spark/DefaultSourceSpec.scala
@@ -1,5 +1,7 @@
 package tech.sourced.gitbase.spark
 
+import java.util.Properties
+
 
 class DefaultSourceSpec extends BaseGitbaseSpec {
 
@@ -336,6 +338,25 @@ class DefaultSourceSpec extends BaseGitbaseSpec {
       ("XML", 1),
       ("desktop", 1)
     ))
+  }
+
+  it should "pull data using JDBC correctly" in {
+    val props = new Properties()
+    props.put("user", "root")
+    props.put("password", "")
+    props.put("driver", "org.mariadb.jdbc.Driver")
+
+    val rcdf = spark.read.jdbc(s"jdbc:mariadb://$server/gitbase", "ref_commits", props)
+
+    val result = rcdf.collect()
+    result.length should be(spark.table("ref_commits").count())
+
+    result.foreach(row => {
+      row(0).toString should not(be("repository_id"))
+      row(1).toString should not(be("commit_hash"))
+      row(2).toString should not(be("ref_name"))
+      row(3).isInstanceOf[Long] should be(true)
+    })
   }
 
 }


### PR DESCRIPTION
Fixes #86

When using MariaDB JDBC dialect, the identifiers are quoted using double quotes, which
Gitbase interprets as a string, not a quoted identifier (as does MySQL).
This adds quoteIdentifier to the GitbaseDialect to quote using backticks and registers
the dialect globally so it's used instead of the default MariaDB one.