### PR TITLE
docs: add note about oniguruma regexps on gitbase

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ Output:
 +-------------------------------------------------------------------------------+----------------------------------------+-------------------+
 ```
 
+## Regular expressions
+
+When a query is executed using `gitbase-spark-connector`, that query either fully or partially will be sent down for `gitbase` to execute.
+`gitbase` uses oniguruma as its regular expression engine, which is different to the one being used by Spark. So, regular expressions need to be written in a way that can be executed in both places, because depending on the query it can be executed in just one of the places or both.
+
+- [Oniguruma syntax](https://github.com/geoffgarside/oniguruma/blob/master/Syntax.txt)
+- [Java regular expression syntax](https://docs.oracle.com/javase/9/docs/api/java/util/regex/Pattern.html)
+
 ## License
 
 Apache License 2.0, see [LICENSE](/LICENSE)


### PR DESCRIPTION
Closes #77 

I've been doing some research trying to find some place with the differences between both engines, but didn't find it and doing it by hand seemed like too much for this task, so I settled with just adding this to the docs of gitbase-spark-connector.