### PR TITLE
Add Main file to start a thrift server easly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ lazy val root = (project in file(".")).
     name := "gitbase-spark-connector",
 
     libraryDependencies += sparkSql % Provided,
+    libraryDependencies += sparkHiveThriftserver % Provided,
     libraryDependencies ++= Seq(
       scalaTest % Test,
       dockerJava % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,8 @@ import sbt._
 
 object Dependencies {
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
-  lazy val sparkSql = "org.apache.spark" % "spark-sql_2.11" % "2.3.1"
+  lazy val sparkSql = "org.apache.spark" %% "spark-sql" % "2.3.1"
+  lazy val sparkHiveThriftserver = "org.apache.spark" %% "spark-hive-thriftserver" % "2.3.1"
   lazy val mariaDB = "org.mariadb.jdbc" % "mariadb-java-client" % "2.3.0"
   lazy val enry = "tech.sourced" % "enry-java" % "1.7.1"
   lazy val bblfsh = "org.bblfsh" % "bblfsh-client" % "1.10.1"

--- a/src/main/scala/tech/sourced/gitbase/spark/StartThriftServer.scala
+++ b/src/main/scala/tech/sourced/gitbase/spark/StartThriftServer.scala
@@ -1,0 +1,19 @@
+package tech.sourced.gitbase.spark
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.hive.thriftserver.HiveThriftServer2
+
+object StartThriftServer extends App with Logging {
+
+  logInfo("Registering gitbase-spark-connector...")
+
+  val spark = SparkSession.builder().appName("Thrift server with gitbase")
+    .registerGitbaseSource()
+    .config("spark.sql.hive.thriftServer.singleSession","true")
+    .getOrCreate()
+
+  logInfo("gitbase-spark-connector registered!")
+
+  HiveThriftServer2.startWithContext(spark.sqlContext)
+}


### PR DESCRIPTION
Main class to execute a Spark job with a Hive thrift server and gitbase.

How to execute:

```
./bin/spark-submit --master local[*] --class tech.sourced.gitbase.spark.StartThriftServer /home/antonio/workspace/gitbase-spark-connector/target/gitbase-spark-connector-uber.jar
```

Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>